### PR TITLE
feat(lapic-ufjf/searchat-behavior#8): allow researchers to reorder questionnaire questions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "dependencies": {
     "@craco/craco": "^7.1.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@fontsource/roboto": "^5.2.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,15 @@ importers:
       '@craco/craco':
         specifier: ^7.1.0
         version: 7.1.0(@types/node@25.5.0)(postcss@8.5.8)(react-scripts@5.0.1(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(@types/babel__core@7.20.5)(eslint@8.57.1)(react@18.3.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.7.3))(type-fest@0.21.3)(typescript@5.7.3)(yaml@2.8.2))(typescript@5.7.3)
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@18.3.1)
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(@types/react@19.2.14)(react@18.3.1)
@@ -976,6 +985,28 @@ packages:
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss-selector-parser: ^6.0.10
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -7773,6 +7804,31 @@ snapshots:
   '@csstools/selector-specificity@2.2.0(postcss-selector-parser@6.1.2)':
     dependencies:
       postcss-selector-parser: 6.1.2
+
+  '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      react: 18.3.1
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:

--- a/src/components/Modals/CreateQuestionnaire.js
+++ b/src/components/Modals/CreateQuestionnaire.js
@@ -26,8 +26,10 @@ import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { api } from '../../config/axios';
 import useQuestionnaireForm from '../Questionnaire/useQuestionnaireForm';
-import QuestionCard from '../Questionnaire/QuestionCard';
+import SortableQuestionCard from '../Questionnaire/SortableQuestionCard';
 import { useState } from 'react';
+import { DndContext, closestCenter, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 
 const SURVEY_TYPES = (t) => [
   { value: 'pre', label: t('pre') },
@@ -65,11 +67,14 @@ const CreateQuestionnaire = ({
     addQuestion,
     removeQuestion,
     updateQuestion,
+    reorderQuestions,
     isValid,
     buildPayload,
     reset,
     hasEmptyStatement,
   } = useQuestionnaireForm();
+
+  const sensors = useSensors(useSensor(PointerSensor));
 
   const surveyTypes = SURVEY_TYPES(t);
   const questionTypes = QUESTION_TYPES(t);
@@ -184,17 +189,30 @@ const CreateQuestionnaire = ({
             {t('questions')}
           </Typography>
 
-          {questions.map((q, idx) => (
-            <QuestionCard
-              key={q.id}
-              q={q}
-              index={idx}
-              questionTypes={questionTypes}
-              t={t}
-              onUpdate={updateQuestion}
-              onRemove={removeQuestion}
-            />
-          ))}
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={({ active, over }) => {
+              if (over && active.id !== over.id) reorderQuestions(active.id, over.id);
+            }}
+          >
+            <SortableContext
+              items={questions.map((q) => q.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              {questions.map((q, idx) => (
+                <SortableQuestionCard
+                  key={q.id}
+                  q={q}
+                  index={idx}
+                  questionTypes={questionTypes}
+                  t={t}
+                  onUpdate={updateQuestion}
+                  onRemove={removeQuestion}
+                />
+              ))}
+            </SortableContext>
+          </DndContext>
 
           <Button
             variant="outlined"

--- a/src/components/Modals/EditQuestionnaireDialog.js
+++ b/src/components/Modals/EditQuestionnaireDialog.js
@@ -21,7 +21,9 @@ import {
 import { Add } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
 import useQuestionnaireForm from '../Questionnaire/useQuestionnaireForm';
-import QuestionCard from '../Questionnaire/QuestionCard';
+import SortableQuestionCard from '../Questionnaire/SortableQuestionCard';
+import { DndContext, closestCenter, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 
 const SURVEY_TYPES = (t) => [
   { value: 'pre', label: t('pre') },
@@ -52,10 +54,13 @@ const EditQuestionnaireDialog = ({ open, onClose, survey, onSave }) => {
     addQuestion,
     removeQuestion,
     updateQuestion,
+    reorderQuestions,
     isValid,
     buildPayload,
     hasEmptyStatement,
   } = useQuestionnaireForm(survey);
+
+  const sensors = useSensors(useSensor(PointerSensor));
 
   useEffect(() => {
     if (survey) {
@@ -154,17 +159,30 @@ const EditQuestionnaireDialog = ({ open, onClose, survey, onSave }) => {
             {t('questions')}
           </Typography>
 
-          {questions.map((q, idx) => (
-            <QuestionCard
-              key={q.id}
-              q={q}
-              index={idx}
-              questionTypes={questionTypes}
-              t={t}
-              onUpdate={updateQuestion}
-              onRemove={removeQuestion}
-            />
-          ))}
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={({ active, over }) => {
+              if (over && active.id !== over.id) reorderQuestions(active.id, over.id);
+            }}
+          >
+            <SortableContext
+              items={questions.map((q) => q.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              {questions.map((q, idx) => (
+                <SortableQuestionCard
+                  key={q.id}
+                  q={q}
+                  index={idx}
+                  questionTypes={questionTypes}
+                  t={t}
+                  onUpdate={updateQuestion}
+                  onRemove={removeQuestion}
+                />
+              ))}
+            </SortableContext>
+          </DndContext>
 
           <Button
             variant="outlined"

--- a/src/components/Questionnaire/QuestionCard.js
+++ b/src/components/Questionnaire/QuestionCard.js
@@ -21,10 +21,19 @@ import {
   Radio,
   Checkbox,
 } from '@mui/material';
-import { Delete as DeleteIcon } from '@mui/icons-material';
+import { Delete as DeleteIcon, DragIndicator } from '@mui/icons-material';
 import ClearIcon from '@mui/icons-material/Clear';
 
-const QuestionCard = ({ q, index, questionTypes, t, onUpdate, onRemove }) => {
+const QuestionCard = ({
+  q,
+  index,
+  questionTypes,
+  t,
+  onUpdate,
+  onRemove,
+  dragHandleProps,
+  isDragging,
+}) => {
   const isChoice = q.type === 'multiple-selection' || q.type === 'multiple-choices';
   const hasNoOptions = isChoice && q.options.length === 0;
   const OptionIcon = q.type === 'multiple-choices' ? Radio : Checkbox;
@@ -55,12 +64,21 @@ const QuestionCard = ({ q, index, questionTypes, t, onUpdate, onRemove }) => {
         border: '1px solid #e0e0e0',
         borderLeft: '5px solid #0d5086',
         backgroundColor: '#fff',
-        boxShadow: 1,
+        boxShadow: isDragging ? 6 : 1,
+        opacity: isDragging ? 0.85 : 1,
         transition: 'box-shadow 0.2s',
-        '&:hover': { boxShadow: 3 },
+        '&:hover': { boxShadow: isDragging ? 6 : 3 },
       }}
     >
       <Box sx={{ p: 2, display: 'flex', gap: 2, alignItems: 'flex-start', flexWrap: 'wrap' }}>
+        {dragHandleProps && (
+          <Box
+            {...dragHandleProps}
+            sx={{ display: 'flex', alignItems: 'center', cursor: 'grab', color: '#bbb', pt: 1.5 }}
+          >
+            <DragIndicator />
+          </Box>
+        )}
         <TextField
           label={t('questionStatement', { index: index + 1 })}
           value={q.statement}

--- a/src/components/Questionnaire/SortableQuestionCard.js
+++ b/src/components/Questionnaire/SortableQuestionCard.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026, lapic-ufjf
+ * Licensed under The MIT License [see LICENSE for details]
+ */
+
+import React from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import QuestionCard from './QuestionCard';
+
+const SortableQuestionCard = (props) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: props.q.id,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <QuestionCard
+        {...props}
+        dragHandleProps={{ ...listeners, ...attributes }}
+        isDragging={isDragging}
+      />
+    </div>
+  );
+};
+
+export default SortableQuestionCard;

--- a/src/components/Questionnaire/useQuestionnaireForm.js
+++ b/src/components/Questionnaire/useQuestionnaireForm.js
@@ -5,6 +5,7 @@
 
 import { useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
+import { arrayMove } from '@dnd-kit/sortable';
 
 const useQuestionnaireForm = (initial = {}) => {
   const [title, setTitle] = useState(initial.title || '');
@@ -44,6 +45,13 @@ const useQuestionnaireForm = (initial = {}) => {
 
   const updateQuestion = (qId, field, value) =>
     setQuestions((prev) => prev.map((q) => (q.id === qId ? { ...q, [field]: value } : q)));
+
+  const reorderQuestions = (activeId, overId) =>
+    setQuestions((prev) => {
+      const oldIndex = prev.findIndex((q) => q.id === activeId);
+      const newIndex = prev.findIndex((q) => q.id === overId);
+      return arrayMove(prev, oldIndex, newIndex);
+    });
 
   const buildPayload = () => ({
     name: title,
@@ -98,6 +106,7 @@ const useQuestionnaireForm = (initial = {}) => {
     addQuestion,
     removeQuestion,
     updateQuestion,
+    reorderQuestions,
     isValid,
     hasInvalidChoiceQuestion,
     buildPayload,


### PR DESCRIPTION
- Installs `@dnd-kit/core`, `@dnd-kit/sortable` and `@dnd-kit/utilities` for drag-and-drop support
- Adds `reorderQuestions` to `useQuestionnaireForm` hook using `arrayMove`
- Adds a drag handle (`DragIndicator` icon) to `QuestionCard`
- Creates `SortableQuestionCard` wrapper connecting dnd-kit's `useSortable` to `QuestionCard`
- Wires up `DndContext` + `SortableContext` in both `CreateQuestionnaire` and `EditQuestionnaireDialog`