### PR TITLE
feat(lapic-ufjf/searchat-behavior#12): autosave experiment drafts to prevent data loss during creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "i18next-browser-languagedetector": "^7.2.2",
     "i18next-http-backend": "^2.7.3",
     "js-cookie": "^3.0.5",
+    "js-yaml": "^5.2.0",
     "marked": "^16.4.2",
     "md5": "^2.3.0",
     "primeicons": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,12 @@ importers:
       '@fontsource/roboto':
         specifier: ^5.2.10
         version: 5.2.10
+      '@google/genai':
+        specifier: ^1.45.0
+        version: 1.52.0
+      '@material/web':
+        specifier: ^2.4.1
+        version: 2.4.1
       '@mui/icons-material':
         specifier: ^6.5.0
         version: 6.5.0(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@19.2.14)(react@18.3.1)
@@ -38,9 +44,27 @@ importers:
       '@mui/styles':
         specifier: ^6.4.8
         version: 6.4.8(@types/react@19.2.14)(react@18.3.1)
+      '@mui/x-date-pickers':
+        specifier: ^8.27.2
+        version: 8.29.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react@18.3.1))(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      ajv:
+        specifier: ^8.18.0
+        version: 8.18.0
       axios:
         specifier: ^1.13.6
         version: 1.13.6
+      bcrypt:
+        specifier: ^5.1.1
+        version: 5.1.1
+      bootstrap:
+        specifier: ^5.3.8
+        version: 5.3.8(@popperjs/core@2.11.8)
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.4.0
+      dompurify:
+        specifier: ^3.3.3
+        version: 3.4.11
       i18next:
         specifier: ^23.16.8
         version: 23.16.8
@@ -53,6 +77,9 @@ importers:
       js-cookie:
         specifier: ^3.0.5
         version: 3.0.5
+      js-yaml:
+        specifier: ^5.2.0
+        version: 5.2.0
       marked:
         specifier: ^16.4.2
         version: 16.4.2
@@ -68,12 +95,21 @@ importers:
       react:
         specifier: ^18.3.1
         version: 18.3.1
+      react-bootstrap:
+        specifier: ^2.10.10
+        version: 2.10.10(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-breadcrumbs-dynamic:
+        specifier: ^1.2.1
+        version: 1.2.1(react@18.3.1)
       react-cookie:
         specifier: ^6.1.3
         version: 6.1.3(@types/react@19.2.14)(react@18.3.1)
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-google-button:
+        specifier: ^0.7.2
+        version: 0.7.2(react@18.3.1)
       react-i18next:
         specifier: ^14.1.3
         version: 14.1.3(i18next@23.16.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -108,6 +144,9 @@ importers:
       '@babel/plugin-proposal-private-property-in-object':
         specifier: ^7.21.11
         version: 7.21.11(@babel/core@7.29.0)
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -1026,6 +1065,9 @@ packages:
   '@emotion/weak-memoize@0.4.0':
     resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
 
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
+
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1047,6 +1089,15 @@ packages:
   '@fontsource/roboto@5.2.10':
     resolution: {integrity: sha512-8HlA5FtSfz//oFSr2eL7GFXAiE7eIkcGOtx7tjsLKq+as702x9+GU7K95iDeWFapHC4M2hv9RrpXKRTGGBI8Zg==}
 
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -1059,6 +1110,15 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+
+  '@internationalized/date@3.12.2':
+    resolution: {integrity: sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==}
+
+  '@internationalized/number@3.6.7':
+    resolution: {integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==}
+
+  '@internationalized/string@3.2.9':
+    resolution: {integrity: sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==}
 
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
@@ -1163,6 +1223,19 @@ packages:
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
 
+  '@lit-labs/ssr-dom-shim@1.6.0':
+    resolution: {integrity: sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==}
+
+  '@lit/reactive-element@2.1.2':
+    resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
+
+  '@mapbox/node-pre-gyp@1.0.11':
+    resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
+    hasBin: true
+
+  '@material/web@2.4.1':
+    resolution: {integrity: sha512-0sk9t25acJ72Qv3r0n9r0lgDbPaAKnpm0p+QmEAAwYyZomHxuVbgrrAdtNXaRm7jFyGh+WsTr8bhtvCnpPRFjw==}
+
   '@mui/core-downloads-tracker@6.5.0':
     resolution: {integrity: sha512-LGb8t8i6M2ZtS3Drn3GbTI1DVhDY6FJ9crEey2lZ0aN2EMZo8IZBZj9wRf4vqbZHaWjsYgtbOnJw5V8UWbmK2Q==}
 
@@ -1255,6 +1328,14 @@ packages:
       '@types/react':
         optional: true
 
+  '@mui/types@7.4.12':
+    resolution: {integrity: sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@mui/utils@6.4.9':
     resolution: {integrity: sha512-Y12Q9hbK9g+ZY0T3Rxrx9m2m10gaphDuUMgWxyV5kNJevVxXYCLclYUCC9vXaIk1/NdNDTcW2Yfr2OGvNFNmHg==}
     engines: {node: '>=14.0.0'}
@@ -1264,6 +1345,59 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@mui/utils@7.3.11':
+    resolution: {integrity: sha512-XTjGnifwteg71/ij+0e7Y7d+hwyntMYP5wPoA/g2drdGH+Flkvjwy0OfrVpKBbaOvofq4zU/LIyUZyKgmWu18g==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/x-date-pickers@8.29.0':
+    resolution: {integrity: sha512-JfMSg7z9OCgaBg3DMhsSqGPkbkHnGZxZk+bx+i8/cNHTQmvJpUPPLhHc7KtbxEqvYSv9PNNg4NU/bB0JGUFebg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^5.15.14 || ^6.0.0 || ^7.0.0
+      '@mui/system': ^5.15.14 || ^6.0.0 || ^7.0.0
+      date-fns: ^2.25.0 || ^3.2.0 || ^4.0.0
+      date-fns-jalali: ^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0
+      dayjs: ^1.10.7
+      luxon: ^3.0.2
+      moment: ^2.29.4
+      moment-hijri: ^2.1.2 || ^3.0.0
+      moment-jalaali: ^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      date-fns:
+        optional: true
+      date-fns-jalali:
+        optional: true
+      dayjs:
+        optional: true
+      luxon:
+        optional: true
+      moment:
+        optional: true
+      moment-hijri:
+        optional: true
+      moment-jalaali:
+        optional: true
+
+  '@mui/x-internals@8.29.0':
+    resolution: {integrity: sha512-xlqq765k39g6vkVGIypOBlsdYGawIP0JdSh+qqrkUCIIN39AUZRNMA/nGH0nSkhVHMHcCSDWBM5/6+6BLfc7Mg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
@@ -1309,6 +1443,45 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
+  '@react-aria/ssr@3.10.1':
+    resolution: {integrity: sha512-jn038/ZYmu6DpfXJ6r2U9zFFppjbc9wnApPJSCxao2RZVEqep4YyoniHSy8qv6V21/xyS4IV7W9a+X2jOjSuag==}
+    engines: {node: '>= 12'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/shared@3.36.0':
+    resolution: {integrity: sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   '@reduxjs/toolkit@2.11.2':
     resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
     peerDependencies:
@@ -1323,6 +1496,22 @@ packages:
   '@remix-run/router@1.23.2':
     resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
     engines: {node: '>=14.0.0'}
+
+  '@restart/hooks@0.4.16':
+    resolution: {integrity: sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@restart/hooks@0.5.1':
+    resolution: {integrity: sha512-EMoH04NHS1pbn07iLTjIjgttuqb7qu4+/EyhAx27MHpoENcB2ZdSsLTNxmKD+WEPnZigo62Qc8zjGnNxoSE/5Q==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@restart/ui@1.9.4':
+    resolution: {integrity: sha512-N4C7haUc3vn4LTwVUPlkJN8Ach/+yIMvRuTVIhjilNHqegY60SGLrzud6errOMNJwSnmYFnt1J0H/k8FE3A4KA==}
+    peerDependencies:
+      react: '>=16.14.0'
+      react-dom: '>=16.14.0'
 
   '@rollup/plugin-babel@5.3.1':
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
@@ -1431,6 +1620,9 @@ packages:
   '@svgr/webpack@5.5.0':
     resolution: {integrity: sha512-DOBOK255wfQxguUta2INKkzPj6AIS6iafZYiYmHn6W3pHlycSRRlvWKCfLDG10fXfLWqE3DJHgRUOyJYmARa7g==}
     engines: {node: '>=10'}
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@tootallnate/once@1.1.2':
     resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
@@ -1632,6 +1824,9 @@ packages:
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
+  '@types/warning@3.0.4':
+    resolution: {integrity: sha512-CqN8MnISMwQbLJXO3doBAV4Yw9hx9/Pyr2rZ78+NfaCnhyRA/nKrpyk6E7mKw17ZOaQdLpK9GiUjrqLzBlN3sg==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -1767,6 +1962,9 @@ packages:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
     deprecated: Use your platform's native atob() and btoa() methods instead
 
+  abbrev@1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -1814,6 +2012,10 @@ packages:
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -1888,6 +2090,14 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  aproba@2.1.0:
+    resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
+
+  are-we-there-yet@2.0.0:
+    resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
+    engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
+
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
@@ -1899,6 +2109,10 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -2059,6 +2273,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.7:
     resolution: {integrity: sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==}
     engines: {node: '>=6.0.0'}
@@ -2067,12 +2284,19 @@ packages:
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
 
+  bcrypt@5.1.1:
+    resolution: {integrity: sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==}
+    engines: {node: '>= 10.0.0'}
+
   bfj@7.1.0:
     resolution: {integrity: sha512-I6MMLkn+anzNdCUp9hMRyui1HaNEUCco50lxbvNS4+EyXg8lN3nJ48PjPWtbH8UVS9CuMoaKE9U2V3l29DaRQw==}
     engines: {node: '>= 8.0.0'}
 
   big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -2090,6 +2314,11 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  bootstrap@5.3.8:
+    resolution: {integrity: sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==}
+    peerDependencies:
+      '@popperjs/core': ^2.11.8
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -2111,6 +2340,9 @@ packages:
 
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -2193,6 +2425,10 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
@@ -2203,6 +2439,9 @@ packages:
 
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  classnames@2.5.1:
+    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
   clean-css@5.3.3:
     resolution: {integrity: sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==}
@@ -2254,6 +2493,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-support@1.1.3:
+    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
+    hasBin: true
 
   colord@2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
@@ -2308,6 +2551,9 @@ packages:
   connect-history-api-fallback@2.0.0:
     resolution: {integrity: sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==}
     engines: {node: '>=0.8'}
+
+  console-control-strings@1.1.0:
+    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
@@ -2364,6 +2610,11 @@ packages:
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   cross-fetch@4.0.0:
     resolution: {integrity: sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==}
@@ -2562,6 +2813,10 @@ packages:
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-urls@2.0.0:
     resolution: {integrity: sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==}
     engines: {node: '>=10'}
@@ -2577,6 +2832,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -2643,6 +2901,9 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  delegates@1.0.0:
+    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
+
   depd@1.1.2:
     resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
     engines: {node: '>= 0.6'}
@@ -2651,9 +2912,17 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -2724,6 +2993,9 @@ packages:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
 
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+
   domutils@1.7.0:
     resolution: {integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==}
 
@@ -2746,6 +3018,9 @@ packages:
 
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -3094,6 +3369,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -3184,6 +3463,10 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -3202,6 +3485,10 @@ packages:
   fs-extra@9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
+
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
 
   fs-monkey@1.1.0:
     resolution: {integrity: sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==}
@@ -3223,6 +3510,19 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  gauge@3.0.2:
+    resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
+    engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
+
+  gaxios@7.1.5:
+    resolution: {integrity: sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
@@ -3298,6 +3598,14 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  google-auth-library@10.9.0:
+    resolution: {integrity: sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -3344,6 +3652,9 @@ packages:
   has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
+
+  has-unicode@2.0.1:
+    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -3431,6 +3742,10 @@ packages:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
 
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
@@ -3516,6 +3831,9 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  invariant@2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -3929,6 +4247,10 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  js-yaml@5.2.0:
+    resolution: {integrity: sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==}
+    hasBin: true
+
   jsdom@16.7.0:
     resolution: {integrity: sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==}
     engines: {node: '>=10'}
@@ -3942,6 +4264,9 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -4008,6 +4333,12 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -4061,6 +4392,15 @@ packages:
     resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
     engines: {node: '>=20.0.0'}
 
+  lit-element@4.2.2:
+    resolution: {integrity: sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==}
+
+  lit-html@3.3.3:
+    resolution: {integrity: sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==}
+
+  lit@3.3.3:
+    resolution: {integrity: sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==}
+
   loader-runner@4.3.1:
     resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
     engines: {node: '>=6.11.5'}
@@ -4106,6 +4446,9 @@ packages:
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -4222,8 +4565,25 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
+
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
     hasBin: true
 
   ms@2.0.0:
@@ -4264,6 +4624,14 @@ packages:
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
+  node-addon-api@5.1.0:
+    resolution: {integrity: sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
@@ -4277,6 +4645,10 @@ packages:
       encoding:
         optional: true
 
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   node-forge@1.3.3:
     resolution: {integrity: sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==}
     engines: {node: '>= 6.13.0'}
@@ -4286,6 +4658,11 @@ packages:
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+
+  nopt@5.0.0:
+    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -4298,6 +4675,10 @@ packages:
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
+
+  npmlog@5.0.1:
+    resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
+    deprecated: This package is no longer supported.
 
   nth-check@1.0.2:
     resolution: {integrity: sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==}
@@ -4989,8 +5370,17 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  prop-types-extra@1.1.1:
+    resolution: {integrity: sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==}
+    peerDependencies:
+      react: '>=0.14.0'
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  protobufjs@7.6.4:
+    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+    engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -5049,6 +5439,27 @@ packages:
     resolution: {integrity: sha512-sZ41cxiU5llIB003yxxQBYrARBqe0repqPTTYBTmMqTz9szeBbE37BehCE891NZsmdZqqP+xWKdT3eo3vOzN8w==}
     engines: {node: '>=14'}
 
+  react-aria@3.50.0:
+    resolution: {integrity: sha512-S0Os6QZk33fzUAKu1QLT9afoUaCBt1ZNdoiq0n2YMVgKIdNIQS8zxiZ8O9hYE6QyDkHKjD6q39LQZ+qaSAIgjw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react-bootstrap@2.10.10:
+    resolution: {integrity: sha512-gMckKUqn8aK/vCnfwoBpBVFUGT9SVQxwsYrp9yDHt0arXMamxALerliKBxr1TPbntirK/HGrUAHYbAeQTa9GHQ==}
+    peerDependencies:
+      '@types/react': '>=16.14.8'
+      react: '>=16.14.0'
+      react-dom: '>=16.14.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-breadcrumbs-dynamic@1.2.1:
+    resolution: {integrity: sha512-6vw1RHQ2cHaHptRVQ+pwt6Vej/O6NGNBnEzC5fgW53ZhwABKtNW2xpljPppF+L8hVkNDBdjKSVMYp9K2U1j9qw==}
+    peerDependencies:
+      react: '>=16.3.0 || ^16.3.0'
+
   react-cookie@6.1.3:
     resolution: {integrity: sha512-cOToXQPdxvLfK0MH4ZFrrL3cOpDwbboKupFS96MCvrHsHMABMk48vdd1fRWkNG6F5D1JZMvoI5Y74sj8vtHGpA==}
     peerDependencies:
@@ -5071,6 +5482,11 @@ packages:
 
   react-error-overlay@6.1.0:
     resolution: {integrity: sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==}
+
+  react-google-button@0.7.2:
+    resolution: {integrity: sha512-LPIqU2hIlc212kqks8MtKjRstquVkP3SIjxlK5B1nIfg2R7YqSusJAxZUkJA5dv/z6QeSuGyI9ujwV/VWMTyAA==}
+    peerDependencies:
+      react: '*'
 
   react-i18next@14.1.3:
     resolution: {integrity: sha512-wZnpfunU6UIAiJ+bxwOiTmBOAaB14ha97MjOEnLGac2RJ+h/maIYXZuTHlmyqQVX1UVHmU1YDTQ5vxLmwfXTjw==}
@@ -5096,6 +5512,9 @@ packages:
 
   react-is@19.2.4:
     resolution: {integrity: sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==}
+
+  react-lifecycles-compat@3.0.4:
+    resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
 
   react-likert-scale@4.1.2:
     resolution: {integrity: sha512-tSM2M1Vr6Q+W6fdG3KPlEt7BB+/9HrzxtPe6vFrPJNNNGtLg1pb2FLWtXVotKttRT+gCcmq1sFY2Cnr2dDoVbg==}
@@ -5154,6 +5573,16 @@ packages:
     resolution: {integrity: sha512-gMx3SixXBA7ZxsowV6AtZh3ZXoCv6abNRUaoJutVe3Ll9XpSQkFtJ1X2uSTcbUhrRm2BDuj6gqhOgMBAa208yg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
+
+  react-stately@3.48.0:
+    resolution: {integrity: sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react-through@1.1.4:
+    resolution: {integrity: sha512-7VuRPSfKS3ihmMlTgQwOspjd+TV3u7tpFs07MMgLVA0g/bH7UHodKLpGS1LgJJlWTUqJKeN4wT9getqGUN37iA==}
+    peerDependencies:
+      react: '>=16.3.0 || ^16.3.0'
 
   react-tracking@9.3.2:
     resolution: {integrity: sha512-F7miWLnkQIs/13iYJPFl9OlFouD0XXCRt87xsdObL/LJ0D5WquN9azSzA1/fclYZNs5mPTKyJ4cOA/Q8PSVhrw==}
@@ -5437,6 +5866,9 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -5761,6 +6193,11 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
     engines: {node: '>=8'}
@@ -5940,6 +6377,16 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  uncontrollable@7.2.1:
+    resolution: {integrity: sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==}
+    peerDependencies:
+      react: '>=15.0.0'
+
+  uncontrollable@8.0.4:
+    resolution: {integrity: sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==}
+    peerDependencies:
+      react: '>=16.14.0'
+
   underscore@1.13.6:
     resolution: {integrity: sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==}
 
@@ -6056,12 +6503,19 @@ packages:
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
+  warning@4.0.3:
+    resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
+
   watchpack@2.5.1:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
     engines: {node: '>=10.13.0'}
 
   wbuf@1.7.3:
     resolution: {integrity: sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -6180,6 +6634,9 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  wide-align@1.1.5:
+    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
+
   wildcard@2.0.1:
     resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
 
@@ -6294,6 +6751,9 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
@@ -7436,6 +7896,8 @@ snapshots:
 
   '@emotion/weak-memoize@0.4.0': {}
 
+  '@epic-web/invariant@1.0.0': {}
+
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
     dependencies:
       eslint: 8.57.1
@@ -7461,6 +7923,17 @@ snapshots:
 
   '@fontsource/roboto@5.2.10': {}
 
+  '@google/genai@1.52.0':
+    dependencies:
+      google-auth-library: 10.9.0
+      p-retry: 4.6.2
+      protobufjs: 7.6.4
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -7472,6 +7945,18 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@internationalized/date@3.12.2':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@internationalized/number@3.6.7':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@internationalized/string@3.2.9':
+    dependencies:
+      '@swc/helpers': 0.5.23
 
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
@@ -7691,6 +8176,32 @@ snapshots:
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
+  '@lit-labs/ssr-dom-shim@1.6.0': {}
+
+  '@lit/reactive-element@2.1.2':
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.6.0
+
+  '@mapbox/node-pre-gyp@1.0.11':
+    dependencies:
+      detect-libc: 2.1.2
+      https-proxy-agent: 5.0.1
+      make-dir: 3.1.0
+      node-fetch: 2.7.0
+      nopt: 5.0.0
+      npmlog: 5.0.1
+      rimraf: 3.0.2
+      semver: 7.7.4
+      tar: 6.2.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@material/web@2.4.1':
+    dependencies:
+      lit: 3.3.3
+      tslib: 2.8.1
+
   '@mui/core-downloads-tracker@6.5.0': {}
 
   '@mui/icons-material@6.5.0(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@19.2.14)(react@18.3.1)':
@@ -7787,6 +8298,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@mui/types@7.4.12(@types/react@19.2.14)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@mui/utils@6.4.9(@types/react@19.2.14)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.6
@@ -7798,6 +8315,48 @@ snapshots:
       react-is: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@mui/utils@7.3.11(@types/react@19.2.14)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@mui/types': 7.4.12(@types/react@19.2.14)
+      '@types/prop-types': 15.7.15
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-is: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@mui/x-date-pickers@8.29.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react@18.3.1))(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@mui/material': 6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/system': 6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react@18.3.1)
+      '@mui/utils': 7.3.11(@types/react@19.2.14)(react@18.3.1)
+      '@mui/x-internals': 8.29.0(@types/react@19.2.14)(react@18.3.1)
+      '@types/react-transition-group': 4.4.12(@types/react@19.2.14)
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@18.3.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react@18.3.1)
+      date-fns: 4.4.0
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@mui/x-internals@8.29.0(@types/react@19.2.14)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@mui/utils': 7.3.11(@types/react@19.2.14)(react@18.3.1)
+      react: 18.3.1
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     dependencies:
@@ -7832,6 +8391,37 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
+
+  '@react-aria/ssr@3.10.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@swc/helpers': 0.5.23
+      react: 18.3.1
+      react-aria: 3.50.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@react-types/shared@3.36.0(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+
   '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@18.3.1)(redux@5.0.1))(react@18.3.1)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -7845,6 +8435,30 @@ snapshots:
       react-redux: 9.2.0(@types/react@19.2.14)(react@18.3.1)(redux@5.0.1)
 
   '@remix-run/router@1.23.2': {}
+
+  '@restart/hooks@0.4.16(react@18.3.1)':
+    dependencies:
+      dequal: 2.0.3
+      react: 18.3.1
+
+  '@restart/hooks@0.5.1(react@18.3.1)':
+    dependencies:
+      dequal: 2.0.3
+      react: 18.3.1
+
+  '@restart/ui@1.9.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@popperjs/core': 2.11.8
+      '@react-aria/ssr': 3.10.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@restart/hooks': 0.5.1(react@18.3.1)
+      '@types/warning': 3.0.4
+      dequal: 2.0.3
+      dom-helpers: 5.2.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      uncontrollable: 8.0.4(react@18.3.1)
+      warning: 4.0.3
 
   '@rollup/plugin-babel@5.3.1(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@2.80.0)':
     dependencies:
@@ -7971,6 +8585,10 @@ snapshots:
       loader-utils: 2.0.4
     transitivePeerDependencies:
       - supports-color
+
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
 
   '@tootallnate/once@1.1.2': {}
 
@@ -8191,6 +8809,8 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
+  '@types/warning@3.0.4': {}
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 25.5.0
@@ -8381,6 +9001,8 @@ snapshots:
 
   abab@2.0.6: {}
 
+  abbrev@1.1.1: {}
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -8421,6 +9043,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  agent-base@7.1.4: {}
 
   ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
@@ -8484,6 +9108,13 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  aproba@2.1.0: {}
+
+  are-we-there-yet@2.0.0:
+    dependencies:
+      delegates: 1.0.0
+      readable-stream: 3.6.2
+
   arg@4.1.3: {}
 
   arg@5.0.2: {}
@@ -8493,6 +9124,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
 
   aria-query@5.3.2: {}
 
@@ -8748,9 +9383,19 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.7: {}
 
   batch@0.6.1: {}
+
+  bcrypt@5.1.1:
+    dependencies:
+      '@mapbox/node-pre-gyp': 1.0.11
+      node-addon-api: 5.1.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   bfj@7.1.0:
     dependencies:
@@ -8761,6 +9406,8 @@ snapshots:
       tryer: 1.0.1
 
   big.js@5.2.2: {}
+
+  bignumber.js@9.3.1: {}
 
   binary-extensions@2.3.0: {}
 
@@ -8790,6 +9437,10 @@ snapshots:
 
   boolbase@1.0.0: {}
 
+  bootstrap@5.3.8(@popperjs/core@2.11.8):
+    dependencies:
+      '@popperjs/core': 2.11.8
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -8816,6 +9467,8 @@ snapshots:
   bser@2.1.1:
     dependencies:
       node-int64: 0.4.0
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -8897,11 +9550,15 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  chownr@2.0.0: {}
+
   chrome-trace-event@1.0.4: {}
 
   ci-info@3.9.0: {}
 
   cjs-module-lexer@1.4.3: {}
+
+  classnames@2.5.1: {}
 
   clean-css@5.3.3:
     dependencies:
@@ -8954,6 +9611,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  color-support@1.1.3: {}
+
   colord@2.9.3: {}
 
   colorette@2.0.20: {}
@@ -8997,6 +9656,8 @@ snapshots:
   confusing-browser-globals@1.0.11: {}
 
   connect-history-api-fallback@2.0.0: {}
+
+  console-control-strings@1.1.0: {}
 
   content-disposition@0.5.4:
     dependencies:
@@ -9051,6 +9712,11 @@ snapshots:
       yaml: 1.10.2
 
   create-require@1.1.1: {}
+
+  cross-env@10.1.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
 
   cross-fetch@4.0.0:
     dependencies:
@@ -9255,6 +9921,8 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-urls@2.0.0:
     dependencies:
       abab: 2.0.6
@@ -9278,6 +9946,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  date-fns@4.4.0: {}
 
   debug@2.6.9:
     dependencies:
@@ -9330,11 +10000,17 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  delegates@1.0.0: {}
+
   depd@1.1.2: {}
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   destroy@1.2.0: {}
+
+  detect-libc@2.1.2: {}
 
   detect-newline@3.1.0: {}
 
@@ -9403,6 +10079,10 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
+  dompurify@3.4.11:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   domutils@1.7.0:
     dependencies:
       dom-serializer: 0.2.2
@@ -9430,6 +10110,10 @@ snapshots:
       gopd: 1.2.0
 
   duplexer@0.1.2: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -9938,6 +10622,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
@@ -10044,6 +10733,10 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   forwarded@0.2.0: {}
 
   fraction.js@5.3.4: {}
@@ -10062,6 +10755,10 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
       universalify: 2.0.1
+
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
 
   fs-monkey@1.1.0: {}
 
@@ -10082,6 +10779,34 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  gauge@3.0.2:
+    dependencies:
+      aproba: 2.1.0
+      color-support: 1.1.3
+      console-control-strings: 1.1.0
+      has-unicode: 2.0.1
+      object-assign: 4.1.1
+      signal-exit: 3.0.7
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wide-align: 1.1.5
+
+  gaxios@7.1.5:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.5
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   generator-function@2.0.1: {}
 
@@ -10168,6 +10893,19 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  google-auth-library@10.9.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.5
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -10201,6 +10939,8 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
+
+  has-unicode@2.0.1: {}
 
   hasown@2.0.2:
     dependencies:
@@ -10315,6 +11055,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   human-signals@2.1.0: {}
 
   husky@9.1.7: {}
@@ -10389,6 +11136,10 @@ snapshots:
       side-channel: 1.1.0
 
   internmap@2.0.3: {}
+
+  invariant@2.2.4:
+    dependencies:
+      loose-envify: 1.4.0
 
   ipaddr.js@1.9.1: {}
 
@@ -11038,6 +11789,10 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  js-yaml@5.2.0:
+    dependencies:
+      argparse: 2.0.1
+
   jsdom@16.7.0:
     dependencies:
       abab: 2.0.6
@@ -11073,6 +11828,10 @@ snapshots:
       - utf-8-validate
 
   jsesc@3.1.0: {}
+
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
 
   json-buffer@3.0.1: {}
 
@@ -11159,6 +11918,17 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -11211,6 +11981,22 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
 
+  lit-element@4.2.2:
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.6.0
+      '@lit/reactive-element': 2.1.2
+      lit-html: 3.3.3
+
+  lit-html@3.3.3:
+    dependencies:
+      '@types/trusted-types': 2.0.7
+
+  lit@3.3.3:
+    dependencies:
+      '@lit/reactive-element': 2.1.2
+      lit-element: 4.2.2
+      lit-html: 3.3.3
+
   loader-runner@4.3.1: {}
 
   loader-utils@2.0.4:
@@ -11253,6 +12039,8 @@ snapshots:
       slice-ansi: 7.1.2
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
+
+  long@5.3.2: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -11349,9 +12137,22 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
+  minipass@5.0.0: {}
+
+  minizlib@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
+
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
+
+  mkdirp@1.0.4: {}
 
   ms@2.0.0: {}
 
@@ -11385,6 +12186,10 @@ snapshots:
       lower-case: 2.0.2
       tslib: 2.8.1
 
+  node-addon-api@5.1.0: {}
+
+  node-domexception@1.0.0: {}
+
   node-exports-info@1.6.0:
     dependencies:
       array.prototype.flatmap: 1.3.3
@@ -11396,11 +12201,21 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
   node-forge@1.3.3: {}
 
   node-int64@0.4.0: {}
 
   node-releases@2.0.36: {}
+
+  nopt@5.0.0:
+    dependencies:
+      abbrev: 1.1.1
 
   normalize-path@3.0.0: {}
 
@@ -11409,6 +12224,13 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+
+  npmlog@5.0.1:
+    dependencies:
+      are-we-there-yet: 2.0.0
+      console-control-strings: 1.1.0
+      gauge: 3.0.2
+      set-blocking: 2.0.0
 
   nth-check@1.0.2:
     dependencies:
@@ -12094,11 +12916,31 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  prop-types-extra@1.1.1(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-is: 16.13.1
+      warning: 4.0.3
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  protobufjs@7.6.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 25.5.0
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:
@@ -12164,6 +13006,45 @@ snapshots:
       regenerator-runtime: 0.13.11
       whatwg-fetch: 3.6.20
 
+  react-aria@3.50.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@internationalized/date': 3.12.2
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.9
+      '@react-types/shared': 3.36.0(react@18.3.1)
+      '@swc/helpers': 0.5.23
+      aria-hidden: 1.2.6
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-stately: 3.48.0(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+
+  react-bootstrap@2.10.10(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@restart/hooks': 0.4.16(react@18.3.1)
+      '@restart/ui': 1.9.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/prop-types': 15.7.15
+      '@types/react-transition-group': 4.4.12(@types/react@19.2.14)
+      classnames: 2.5.1
+      dom-helpers: 5.2.1
+      invariant: 2.2.4
+      prop-types: 15.8.1
+      prop-types-extra: 1.1.1(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      uncontrollable: 7.2.1(react@18.3.1)
+      warning: 4.0.3
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-breadcrumbs-dynamic@1.2.1(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-through: 1.1.4(react@18.3.1)
+
   react-cookie@6.1.3(@types/react@19.2.14)(react@18.3.1):
     dependencies:
       '@types/hoist-non-react-statics': 3.3.7(@types/react@19.2.14)
@@ -12215,6 +13096,11 @@ snapshots:
 
   react-error-overlay@6.1.0: {}
 
+  react-google-button@0.7.2(react@18.3.1):
+    dependencies:
+      prop-types: 15.8.1
+      react: 18.3.1
+
   react-i18next@14.1.3(i18next@23.16.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.28.6
@@ -12231,6 +13117,8 @@ snapshots:
   react-is@18.3.1: {}
 
   react-is@19.2.4: {}
+
+  react-lifecycles-compat@3.0.4: {}
 
   react-likert-scale@4.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -12360,6 +13248,20 @@ snapshots:
   react-serp-preview@1.1.0(react@18.3.1):
     dependencies:
       prop-types: 15.8.1
+      react: 18.3.1
+
+  react-stately@3.48.0(react@18.3.1):
+    dependencies:
+      '@internationalized/date': 3.12.2
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.9
+      '@react-types/shared': 3.36.0(react@18.3.1)
+      '@swc/helpers': 0.5.23
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+
+  react-through@1.1.4(react@18.3.1):
+    dependencies:
       react: 18.3.1
 
   react-tracking@9.3.2(prop-types@15.8.1)(react@18.3.1):
@@ -12692,6 +13594,8 @@ snapshots:
       send: 0.19.2
     transitivePeerDependencies:
       - supports-color
+
+  set-blocking@2.0.0: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -13090,6 +13994,15 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
+
   temp-dir@2.0.0: {}
 
   tempy@0.6.0:
@@ -13276,6 +14189,18 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  uncontrollable@7.2.1(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@types/react': 19.2.14
+      invariant: 2.2.4
+      react: 18.3.1
+      react-lifecycles-compat: 3.0.4
+
+  uncontrollable@8.0.4(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   underscore@1.13.6: {}
 
   undici-types@7.18.2: {}
@@ -13387,6 +14312,10 @@ snapshots:
     dependencies:
       makeerror: 1.0.12
 
+  warning@4.0.3:
+    dependencies:
+      loose-envify: 1.4.0
+
   watchpack@2.5.1:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -13395,6 +14324,8 @@ snapshots:
   wbuf@1.7.3:
     dependencies:
       minimalistic-assert: 1.0.1
+
+  web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
 
@@ -13591,6 +14522,10 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  wide-align@1.1.5:
+    dependencies:
+      string-width: 4.2.3
+
   wildcard@2.0.1: {}
 
   word-wrap@1.2.5: {}
@@ -13752,6 +14687,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yallist@4.0.0: {}
 
   yaml@1.10.2: {}
 

--- a/src/components/Researcher/DraftExperimentCard.js
+++ b/src/components/Researcher/DraftExperimentCard.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026, lapic-ufjf
+ * Licensed under The MIT License [see LICENSE for details]
+ */
+
+import { Box, Button, Chip, Paper, Typography } from '@mui/material';
+import React from 'react';
+import EditNoteIcon from '@mui/icons-material/EditNote';
+import DeleteIcon from '@mui/icons-material/Delete';
+import styles from '../../style/experimentAccordion.module.css';
+
+const DraftExperimentCard = ({ draft, onContinue, onDiscard, t }) => {
+  const title = draft?.ExperimentTitle?.trim() || t?.('draft_card_untitled');
+  const savedAt = draft?.savedAt ? new Date(draft.savedAt).toLocaleString() : '';
+
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        padding: '16px',
+        marginBottom: '5px',
+        border: '1px dashed #f2912d',
+        backgroundColor: '#fff8ef',
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, marginBottom: '8px', flexWrap: 'wrap' }}>
+        <Typography sx={{ fontSize: '1rem', fontWeight: 500 }}>{title}</Typography>
+        <Chip
+          label={t?.('draft_badge_label') ?? 'Draft'}
+          size="small"
+          sx={{ backgroundColor: '#f2912d', color: '#fff', fontWeight: 500 }}
+        />
+      </Box>
+
+      {savedAt && (
+        <Typography variant="body2" sx={{ color: '#757575', marginBottom: '16px' }}>
+          {t?.('draft_card_last_saved', { date: savedAt }) ?? `Last saved on ${savedAt}`}
+        </Typography>
+      )}
+
+      <Box className={styles.buttonContainer}>
+        <Button
+          variant="contained"
+          size="small"
+          className={styles.actionButton}
+          startIcon={<EditNoteIcon />}
+          onClick={onContinue}
+          sx={{ boxShadow: 'none' }}
+        >
+          {t?.('draft_card_continue') ?? 'Continue draft'}
+        </Button>
+        <Button
+          variant="outlined"
+          size="small"
+          color="error"
+          className={styles.actionButton}
+          startIcon={<DeleteIcon />}
+          onClick={onDiscard}
+        >
+          {t?.('draft_card_discard') ?? 'Discard'}
+        </Button>
+      </Box>
+    </Paper>
+  );
+};
+
+export { DraftExperimentCard };

--- a/src/hooks/useExperimentDraftAutosave.js
+++ b/src/hooks/useExperimentDraftAutosave.js
@@ -4,6 +4,7 @@
  */
 
 import { useEffect, useRef } from 'react';
+import { api } from '../config/axios';
 
 const DRAFT_VERSION = 1;
 const AUTOSAVE_DEBOUNCE_MS = 800;
@@ -40,11 +41,68 @@ export const isExperimentDraftMeaningful = (draft) => {
   );
 };
 
+// Mirrors the local draft to the backend so it survives a lost/cleared
+// browser too, not just a crash. Best-effort: the local copy in
+// localStorage remains the source of truth if this fails (offline backend).
+export const saveExperimentDraftToServer = async (user, values) => {
+  if (!user?.id) return;
+  try {
+    await api.put(
+      `/experiment-draft/${user.id}`,
+      { payload: values },
+      { headers: { Authorization: `Bearer ${user.accessToken}` } },
+    );
+  } catch (error) {
+    console.error('Erro ao salvar rascunho do experimento no servidor:', error);
+  }
+};
+
+export const loadExperimentDraftFromServer = async (user) => {
+  if (!user?.id) return null;
+  try {
+    const { data } = await api.get(`/experiment-draft/${user.id}`, {
+      headers: { Authorization: `Bearer ${user.accessToken}` },
+    });
+    if (!data?.payload) return null;
+    return { ...data.payload, savedAt: data.lastChangeAt };
+  } catch (error) {
+    console.error('Erro ao carregar rascunho do experimento do servidor:', error);
+    return null;
+  }
+};
+
+export const clearExperimentDraftFromServer = async (user) => {
+  if (!user?.id) return;
+  try {
+    await api.delete(`/experiment-draft/${user.id}`, {
+      headers: { Authorization: `Bearer ${user.accessToken}` },
+    });
+  } catch (error) {
+    console.error('Erro ao limpar rascunho do experimento no servidor:', error);
+  }
+};
+
+// Picks whichever of the two drafts was saved more recently, so a
+// researcher who resumes on a different device (or after clearing
+// localStorage) still gets their latest progress.
+export const pickFreshestDraft = (localDraft, serverDraft) => {
+  const hasLocal = isExperimentDraftMeaningful(localDraft);
+  const hasServer = isExperimentDraftMeaningful(serverDraft);
+  if (!hasLocal) return hasServer ? serverDraft : null;
+  if (!hasServer) return localDraft;
+
+  const localTime = new Date(localDraft.savedAt || 0).getTime();
+  const serverTime = new Date(serverDraft.savedAt || 0).getTime();
+  return serverTime > localTime ? serverDraft : localDraft;
+};
+
 // Persists `values` to localStorage (debounced) so an in-progress experiment
 // survives backend failures, refreshes or crashes before the final submit.
-export const useExperimentDraftAutosave = (userId, values, { enabled }) => {
+// Also mirrors the same values to the backend when reachable.
+export const useExperimentDraftAutosave = (user, values, { enabled }) => {
   const timeoutRef = useRef(null);
   const lastSavedRef = useRef(null);
+  const userId = user?.id;
 
   useEffect(() => {
     if (!enabled || !userId) return undefined;
@@ -54,21 +112,20 @@ export const useExperimentDraftAutosave = (userId, values, { enabled }) => {
 
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
     timeoutRef.current = setTimeout(() => {
+      const draftWithMeta = {
+        ...values,
+        version: DRAFT_VERSION,
+        savedAt: new Date().toISOString(),
+      };
       try {
-        window.localStorage.setItem(
-          storageKey(userId),
-          JSON.stringify({
-            ...values,
-            version: DRAFT_VERSION,
-            savedAt: new Date().toISOString(),
-          }),
-        );
+        window.localStorage.setItem(storageKey(userId), JSON.stringify(draftWithMeta));
         lastSavedRef.current = serialized;
       } catch (error) {
         console.error('Erro ao salvar rascunho do experimento:', error);
       }
+      saveExperimentDraftToServer(user, draftWithMeta);
     }, AUTOSAVE_DEBOUNCE_MS);
 
     return () => clearTimeout(timeoutRef.current);
-  }, [userId, values, enabled]);
+  }, [user, userId, values, enabled]);
 };

--- a/src/hooks/useExperimentDraftAutosave.js
+++ b/src/hooks/useExperimentDraftAutosave.js
@@ -3,11 +3,18 @@
  * Licensed under The MIT License [see LICENSE for details]
  */
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { api } from '../config/axios';
 
 const DRAFT_VERSION = 1;
 const AUTOSAVE_DEBOUNCE_MS = 800;
+
+export const AUTOSAVE_STATUS = {
+  IDLE: 'idle',
+  SAVING: 'saving',
+  SAVED: 'saved',
+  ERROR: 'error',
+};
 
 const storageKey = (userId) => `experiment_draft_${userId}`;
 
@@ -45,15 +52,17 @@ export const isExperimentDraftMeaningful = (draft) => {
 // browser too, not just a crash. Best-effort: the local copy in
 // localStorage remains the source of truth if this fails (offline backend).
 export const saveExperimentDraftToServer = async (user, values) => {
-  if (!user?.id) return;
+  if (!user?.id) return false;
   try {
     await api.put(
       `/experiment-draft/${user.id}`,
       { payload: values },
       { headers: { Authorization: `Bearer ${user.accessToken}` } },
     );
+    return true;
   } catch (error) {
     console.error('Erro ao salvar rascunho do experimento no servidor:', error);
+    return false;
   }
 };
 
@@ -98,11 +107,22 @@ export const pickFreshestDraft = (localDraft, serverDraft) => {
 
 // Persists `values` to localStorage (debounced) so an in-progress experiment
 // survives backend failures, refreshes or crashes before the final submit.
-// Also mirrors the same values to the backend when reachable.
+// Also mirrors the same values to the backend when reachable, and reports
+// the outcome so the caller can warn the user when the backend is unreachable.
 export const useExperimentDraftAutosave = (user, values, { enabled }) => {
   const timeoutRef = useRef(null);
+  const savedFeedbackTimeoutRef = useRef(null);
   const lastSavedRef = useRef(null);
   const userId = user?.id;
+  const [status, setStatus] = useState(AUTOSAVE_STATUS.IDLE);
+
+  useEffect(
+    () => () => {
+      clearTimeout(timeoutRef.current);
+      clearTimeout(savedFeedbackTimeoutRef.current);
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!enabled || !userId) return undefined;
@@ -111,21 +131,34 @@ export const useExperimentDraftAutosave = (user, values, { enabled }) => {
     if (serialized === lastSavedRef.current) return undefined;
 
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
-    timeoutRef.current = setTimeout(() => {
+    timeoutRef.current = setTimeout(async () => {
       const draftWithMeta = {
         ...values,
         version: DRAFT_VERSION,
         savedAt: new Date().toISOString(),
       };
+      setStatus(AUTOSAVE_STATUS.SAVING);
       try {
         window.localStorage.setItem(storageKey(userId), JSON.stringify(draftWithMeta));
         lastSavedRef.current = serialized;
       } catch (error) {
         console.error('Erro ao salvar rascunho do experimento:', error);
       }
-      saveExperimentDraftToServer(user, draftWithMeta);
+      const savedToServer = await saveExperimentDraftToServer(user, draftWithMeta);
+
+      clearTimeout(savedFeedbackTimeoutRef.current);
+      if (savedToServer) {
+        setStatus(AUTOSAVE_STATUS.SAVED);
+        savedFeedbackTimeoutRef.current = setTimeout(() => {
+          setStatus(AUTOSAVE_STATUS.IDLE);
+        }, 500);
+      } else {
+        setStatus(AUTOSAVE_STATUS.ERROR);
+      }
     }, AUTOSAVE_DEBOUNCE_MS);
 
     return () => clearTimeout(timeoutRef.current);
   }, [user, userId, values, enabled]);
+
+  return status;
 };

--- a/src/hooks/useExperimentDraftAutosave.js
+++ b/src/hooks/useExperimentDraftAutosave.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, lapic-ufjf
+ * Licensed under The MIT License [see LICENSE for details]
+ */
+
+import { useEffect, useRef } from 'react';
+
+const DRAFT_VERSION = 1;
+const AUTOSAVE_DEBOUNCE_MS = 800;
+
+const storageKey = (userId) => `experiment_draft_${userId}`;
+
+export const loadExperimentDraft = (userId) => {
+  if (!userId) return null;
+  try {
+    const raw = window.localStorage.getItem(storageKey(userId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return parsed?.version === DRAFT_VERSION ? parsed : null;
+  } catch (error) {
+    console.error('Erro ao carregar rascunho do experimento:', error);
+    return null;
+  }
+};
+
+export const clearExperimentDraft = (userId) => {
+  if (!userId) return;
+  window.localStorage.removeItem(storageKey(userId));
+};
+
+export const isExperimentDraftMeaningful = (draft) => {
+  if (!draft) return false;
+  const plainDescription = (draft.ExperimentDesc || '').replace(/<[^>]*>/g, '').trim();
+  return Boolean(
+    draft.ExperimentTitle?.trim() ||
+      plainDescription ||
+      draft.ExperimentTasks?.length ||
+      draft.ExperimentSurveys?.length ||
+      draft.step > 0,
+  );
+};
+
+// Persists `values` to localStorage (debounced) so an in-progress experiment
+// survives backend failures, refreshes or crashes before the final submit.
+export const useExperimentDraftAutosave = (userId, values, { enabled }) => {
+  const timeoutRef = useRef(null);
+  const lastSavedRef = useRef(null);
+
+  useEffect(() => {
+    if (!enabled || !userId) return undefined;
+
+    const serialized = JSON.stringify(values);
+    if (serialized === lastSavedRef.current) return undefined;
+
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      try {
+        window.localStorage.setItem(
+          storageKey(userId),
+          JSON.stringify({
+            ...values,
+            version: DRAFT_VERSION,
+            savedAt: new Date().toISOString(),
+          }),
+        );
+        lastSavedRef.current = serialized;
+      } catch (error) {
+        console.error('Erro ao salvar rascunho do experimento:', error);
+      }
+    }, AUTOSAVE_DEBOUNCE_MS);
+
+    return () => clearTimeout(timeoutRef.current);
+  }, [userId, values, enabled]);
+};

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -488,15 +488,14 @@
   "download_draft_backup": "Download draft (.yaml)",
   "retry": "Retry",
   "draft_export_error": "Error generating the draft backup.",
-  "import_draft": "Import draft (.yaml)",
-  "draft_imported_success": "Draft imported successfully!",
-  "draft_import_error": "Error importing the draft.",
-  "draft_import_invalid_file": "Invalid draft file.",
   "draft_badge_label": "Draft",
   "draft_card_untitled": "Untitled experiment",
   "draft_card_last_saved": "Automatically saved on {{date}}",
   "draft_card_continue": "Continue draft",
   "draft_card_discard": "Discard",
   "discard_draft_title": "Discard draft?",
-  "discard_draft_message": "This will permanently delete the in-progress experiment draft. This action cannot be undone."
+  "discard_draft_message": "This will permanently delete the in-progress experiment draft. This action cannot be undone.",
+  "autosave_saving": "Saving draft...",
+  "autosave_saved": "Draft saved automatically",
+  "autosave_error": "Couldn't reach the server to save your draft automatically. Your progress is still kept in this browser, but we recommend pausing until the connection is restored, so you don't lose work if this browser is closed or crashes."
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -480,5 +480,16 @@
   "resume_draft_title": "Resume draft?",
   "resume_draft_message": "We found an experiment you were creating that wasn't finished. Do you want to continue where you left off or start a new one?",
   "resume_draft_continue": "Resume draft",
-  "resume_draft_discard": "Start new"
+  "resume_draft_discard": "Start new",
+  "experiment_create_network_error": "Could not connect to the server. Check your connection and try again.",
+  "experiment_create_unknown_error": "An unexpected error occurred while saving the experiment.",
+  "experiment_save_failed_title": "Could not save the experiment",
+  "experiment_save_failed_message": "Your data is still filled in on this screen and was automatically saved in this browser. You can also download a backup to continue later, even on a different computer.",
+  "download_draft_backup": "Download draft (.yaml)",
+  "retry": "Retry",
+  "draft_export_error": "Error generating the draft backup.",
+  "import_draft": "Import draft (.yaml)",
+  "draft_imported_success": "Draft imported successfully!",
+  "draft_import_error": "Error importing the draft.",
+  "draft_import_invalid_file": "Invalid draft file."
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -476,5 +476,9 @@
   "copy_invite_link": "Copy invite link",
   "invite_link_copied": "Link copied!",
   "view_task_instructions": "View task instructions",
-  "task_instructions_title": "Task Instructions"
+  "task_instructions_title": "Task Instructions",
+  "resume_draft_title": "Resume draft?",
+  "resume_draft_message": "We found an experiment you were creating that wasn't finished. Do you want to continue where you left off or start a new one?",
+  "resume_draft_continue": "Resume draft",
+  "resume_draft_discard": "Start new"
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -491,5 +491,12 @@
   "import_draft": "Import draft (.yaml)",
   "draft_imported_success": "Draft imported successfully!",
   "draft_import_error": "Error importing the draft.",
-  "draft_import_invalid_file": "Invalid draft file."
+  "draft_import_invalid_file": "Invalid draft file.",
+  "draft_badge_label": "Draft",
+  "draft_card_untitled": "Untitled experiment",
+  "draft_card_last_saved": "Automatically saved on {{date}}",
+  "draft_card_continue": "Continue draft",
+  "draft_card_discard": "Discard",
+  "discard_draft_title": "Discard draft?",
+  "discard_draft_message": "This will permanently delete the in-progress experiment draft. This action cannot be undone."
 }

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -489,15 +489,14 @@
   "download_draft_backup": "Baixar rascunho (.yaml)",
   "retry": "Tentar novamente",
   "draft_export_error": "Erro ao gerar o backup do rascunho.",
-  "import_draft": "Importar rascunho (.yaml)",
-  "draft_imported_success": "Rascunho importado com sucesso!",
-  "draft_import_error": "Erro ao importar o rascunho.",
-  "draft_import_invalid_file": "Arquivo de rascunho inválido.",
   "draft_badge_label": "Rascunho",
   "draft_card_untitled": "Experimento sem título",
   "draft_card_last_saved": "Salvo automaticamente em {{date}}",
   "draft_card_continue": "Continuar rascunho",
   "draft_card_discard": "Descartar",
   "discard_draft_title": "Descartar rascunho?",
-  "discard_draft_message": "Isso vai apagar definitivamente o rascunho do experimento em andamento. Essa ação não pode ser desfeita."
+  "discard_draft_message": "Isso vai apagar definitivamente o rascunho do experimento em andamento. Essa ação não pode ser desfeita.",
+  "autosave_saving": "Salvando rascunho...",
+  "autosave_saved": "Rascunho salvo automaticamente",
+  "autosave_error": "Não foi possível salvar o rascunho automaticamente no servidor. Seu progresso continua neste navegador, mas recomendamos pausar até a conexão ser restabelecida, para não perder o trabalho caso este navegador seja fechado ou trave."
 }

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -492,5 +492,12 @@
   "import_draft": "Importar rascunho (.yaml)",
   "draft_imported_success": "Rascunho importado com sucesso!",
   "draft_import_error": "Erro ao importar o rascunho.",
-  "draft_import_invalid_file": "Arquivo de rascunho inválido."
+  "draft_import_invalid_file": "Arquivo de rascunho inválido.",
+  "draft_badge_label": "Rascunho",
+  "draft_card_untitled": "Experimento sem título",
+  "draft_card_last_saved": "Salvo automaticamente em {{date}}",
+  "draft_card_continue": "Continuar rascunho",
+  "draft_card_discard": "Descartar",
+  "discard_draft_title": "Descartar rascunho?",
+  "discard_draft_message": "Isso vai apagar definitivamente o rascunho do experimento em andamento. Essa ação não pode ser desfeita."
 }

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -481,5 +481,16 @@
   "resume_draft_title": "Continuar rascunho?",
   "resume_draft_message": "Encontramos um experimento que você estava criando e não finalizou. Deseja continuar de onde parou ou começar um novo?",
   "resume_draft_continue": "Continuar rascunho",
-  "resume_draft_discard": "Começar novo"
+  "resume_draft_discard": "Começar novo",
+  "experiment_create_network_error": "Não foi possível conectar ao servidor. Verifique sua conexão e tente novamente.",
+  "experiment_create_unknown_error": "Ocorreu um erro inesperado ao salvar o experimento.",
+  "experiment_save_failed_title": "Não foi possível salvar o experimento",
+  "experiment_save_failed_message": "Seus dados continuam preenchidos nesta tela e foram salvos automaticamente neste navegador. Você também pode baixar um backup para continuar depois, inclusive em outro computador.",
+  "download_draft_backup": "Baixar rascunho (.yaml)",
+  "retry": "Tentar novamente",
+  "draft_export_error": "Erro ao gerar o backup do rascunho.",
+  "import_draft": "Importar rascunho (.yaml)",
+  "draft_imported_success": "Rascunho importado com sucesso!",
+  "draft_import_error": "Erro ao importar o rascunho.",
+  "draft_import_invalid_file": "Arquivo de rascunho inválido."
 }

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -477,5 +477,9 @@
   "copy_invite_link": "Copiar link de convite",
   "invite_link_copied": "Link copiado!",
   "view_task_instructions": "Ver instruções da tarefa",
-  "task_instructions_title": "Instruções da Tarefa"
+  "task_instructions_title": "Instruções da Tarefa",
+  "resume_draft_title": "Continuar rascunho?",
+  "resume_draft_message": "Encontramos um experimento que você estava criando e não finalizou. Deseja continuar de onde parou ou começar um novo?",
+  "resume_draft_continue": "Continuar rascunho",
+  "resume_draft_discard": "Começar novo"
 }

--- a/src/pages/Experiment/CreateExperiment.js
+++ b/src/pages/Experiment/CreateExperiment.js
@@ -21,6 +21,7 @@ import {
   DialogContentText,
   DialogActions,
   Button,
+  LinearProgress,
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 
@@ -32,6 +33,7 @@ import ExperimentICF from '../components/ExperimentForms/ExperimentICF';
 import ExperimentMetadataForm from '../components/ExperimentForms/ExperimentMetadataForm';
 import StudyDesignForm from '../components/ExperimentForms/StudyDesignForm';
 import {
+  AUTOSAVE_STATUS,
   clearExperimentDraft,
   clearExperimentDraftFromServer,
   isExperimentDraftMeaningful,
@@ -85,7 +87,6 @@ const CreateExperiment = () => {
   const [isCurrentStepValid, setIsCurrentStepValid] = useState(true);
 
   const [saveFailure, setSaveFailure] = useState({ open: false, message: '' });
-  const draftFileInputRef = useRef(null);
 
   const applyDraftValues = (values) => {
     setExperimentTitle(values.ExperimentTitle || '');
@@ -128,7 +129,9 @@ const CreateExperiment = () => {
     ExperimentSurveys,
   };
 
-  useExperimentDraftAutosave(user, currentDraftValues, { enabled: !isDraftPromptOpen });
+  const autosaveStatus = useExperimentDraftAutosave(user, currentDraftValues, {
+    enabled: !isDraftPromptOpen,
+  });
 
   const [feedback, setFeedback] = useState({
     open: false,
@@ -179,45 +182,6 @@ const CreateExperiment = () => {
       setFeedback({
         open: true,
         message: t('draft_export_error'),
-        severity: 'error',
-        isLoading: false,
-      });
-    }
-  };
-
-  const handleDraftFileSelected = async (event) => {
-    const file = event.target.files[0];
-    event.target.value = '';
-    if (!file) return;
-
-    if (!file.name.endsWith('.yaml') && !file.name.endsWith('.yml')) {
-      setFeedback({
-        open: true,
-        message: t('import_invalid_file'),
-        severity: 'error',
-        isLoading: false,
-      });
-      return;
-    }
-
-    try {
-      const text = await file.text();
-      const parsed = yaml.load(text);
-      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-        throw new Error('Invalid draft structure');
-      }
-      applyDraftValues(parsed);
-      setFeedback({
-        open: true,
-        message: t('draft_imported_success'),
-        severity: 'success',
-        isLoading: false,
-      });
-    } catch (error) {
-      console.error('Erro ao importar rascunho:', error);
-      setFeedback({
-        open: true,
-        message: t('draft_import_invalid_file'),
         severity: 'error',
         isLoading: false,
       });
@@ -401,18 +365,23 @@ const CreateExperiment = () => {
         {t('Experiment_create')}
       </Typography>
 
-      <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
-        <input
-          ref={draftFileInputRef}
-          type="file"
-          accept=".yaml,.yml"
-          style={{ display: 'none' }}
-          onChange={handleDraftFileSelected}
+      {(autosaveStatus === AUTOSAVE_STATUS.SAVING || autosaveStatus === AUTOSAVE_STATUS.SAVED) && (
+        <LinearProgress
+          role="status"
+          aria-label={t(
+            autosaveStatus === AUTOSAVE_STATUS.SAVING ? 'autosave_saving' : 'autosave_saved',
+          )}
+          sx={{ position: 'fixed', top: 0, left: 0, width: '100%', height: 3, zIndex: 1400 }}
         />
-        <Button size="small" onClick={() => draftFileInputRef.current?.click()}>
-          {t('import_draft')}
-        </Button>
-      </Box>
+      )}
+
+      {autosaveStatus === AUTOSAVE_STATUS.ERROR && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
+          <Alert severity="warning" sx={{ py: 0, alignItems: 'center' }}>
+            {t('autosave_error')}
+          </Alert>
+        </Box>
+      )}
 
       <Stepper sx={{ display: { xs: 'none', sm: 'flex' } }} activeStep={step} alternativeLabel>
         {STEPS.map((s) => (

--- a/src/pages/Experiment/CreateExperiment.js
+++ b/src/pages/Experiment/CreateExperiment.js
@@ -13,6 +13,12 @@ import {
   Snackbar,
   Alert,
   CircularProgress,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 
@@ -23,10 +29,20 @@ import ConfirmCreateExperiment from '../components/ExperimentForms/ConfirmCreate
 import ExperimentICF from '../components/ExperimentForms/ExperimentICF';
 import ExperimentMetadataForm from '../components/ExperimentForms/ExperimentMetadataForm';
 import StudyDesignForm from '../components/ExperimentForms/StudyDesignForm';
+import {
+  clearExperimentDraft,
+  isExperimentDraftMeaningful,
+  loadExperimentDraft,
+  useExperimentDraftAutosave,
+} from '../../hooks/useExperimentDraftAutosave';
 
 const CreateExperiment = () => {
   const { t } = useTranslation();
   const [user] = useState(JSON.parse(localStorage.getItem('user')));
+  const [pendingDraft] = useState(() => loadExperimentDraft(user?.id));
+  const [isDraftPromptOpen, setIsDraftPromptOpen] = useState(() =>
+    isExperimentDraftMeaningful(pendingDraft),
+  );
   const [ExperimentTitle, setExperimentTitle] = useState('');
   const [ExperimentTitleICF, setExperimentTitleICF] = useState('');
   const [ExperimentDescICF, setExperimentDescICF] = useState('');
@@ -40,6 +56,44 @@ const CreateExperiment = () => {
   const [maxStep, setMaxStep] = useState(0);
   const [completedSteps, setCompletedSteps] = useState(new Set());
   const [isCurrentStepValid, setIsCurrentStepValid] = useState(true);
+
+  const handleResumeDraft = () => {
+    setExperimentTitle(pendingDraft.ExperimentTitle || '');
+    setExperimentTitleICF(pendingDraft.ExperimentTitleICF || '');
+    setExperimentDescICF(pendingDraft.ExperimentDescICF || '');
+    setExperimentType(pendingDraft.ExperimentType || 'within-subject');
+    setBtypeExperiment(pendingDraft.BtypeExperiment || 'random');
+    setExperimentDesc(pendingDraft.ExperimentDesc || '');
+    setExperimentTasks(pendingDraft.ExperimentTasks || []);
+    setExperimentSurveys(pendingDraft.ExperimentSurveys || []);
+    setStep(pendingDraft.step || 0);
+    setMaxStep(pendingDraft.maxStep || 0);
+    setCompletedSteps(new Set(pendingDraft.completedSteps || []));
+    setIsDraftPromptOpen(false);
+  };
+
+  const handleDiscardDraft = () => {
+    clearExperimentDraft(user?.id);
+    setIsDraftPromptOpen(false);
+  };
+
+  useExperimentDraftAutosave(
+    user?.id,
+    {
+      step,
+      maxStep,
+      completedSteps: [...completedSteps],
+      ExperimentTitle,
+      ExperimentTitleICF,
+      ExperimentDescICF,
+      ExperimentType,
+      BtypeExperiment,
+      ExperimentDesc,
+      ExperimentTasks,
+      ExperimentSurveys,
+    },
+    { enabled: !isDraftPromptOpen },
+  );
 
   const [feedback, setFeedback] = useState({
     open: false,
@@ -105,6 +159,7 @@ const CreateExperiment = () => {
         { headers: { Authorization: `Bearer ${user.accessToken}` } },
       );
 
+      clearExperimentDraft(user?.id);
       setFeedback({
         open: true,
         message: t('Success') || 'Experimento criado!',
@@ -191,6 +246,19 @@ const CreateExperiment = () => {
 
   return (
     <>
+      <Dialog open={isDraftPromptOpen} onClose={handleDiscardDraft}>
+        <DialogTitle>{t('resume_draft_title')}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{t('resume_draft_message')}</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleDiscardDraft}>{t('resume_draft_discard')}</Button>
+          <Button onClick={handleResumeDraft} variant="contained" autoFocus>
+            {t('resume_draft_continue')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
       <Typography variant="h4" component="h1" gutterBottom align="center">
         {t('Experiment_create')}
       </Typography>

--- a/src/pages/Experiment/CreateExperiment.js
+++ b/src/pages/Experiment/CreateExperiment.js
@@ -3,7 +3,7 @@
  * Licensed under The MIT License [see LICENSE for details]
  */
 
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import * as yaml from 'js-yaml';
 import { api } from '../../config/axios';
 import {
@@ -33,18 +33,43 @@ import ExperimentMetadataForm from '../components/ExperimentForms/ExperimentMeta
 import StudyDesignForm from '../components/ExperimentForms/StudyDesignForm';
 import {
   clearExperimentDraft,
+  clearExperimentDraftFromServer,
   isExperimentDraftMeaningful,
   loadExperimentDraft,
+  loadExperimentDraftFromServer,
+  pickFreshestDraft,
   useExperimentDraftAutosave,
 } from '../../hooks/useExperimentDraftAutosave';
 
 const CreateExperiment = () => {
   const { t } = useTranslation();
   const [user] = useState(JSON.parse(localStorage.getItem('user')));
-  const [pendingDraft] = useState(() => loadExperimentDraft(user?.id));
+  const [pendingDraft, setPendingDraft] = useState(() => loadExperimentDraft(user?.id));
   const [isDraftPromptOpen, setIsDraftPromptOpen] = useState(() =>
     isExperimentDraftMeaningful(pendingDraft),
   );
+  const hasUserActedOnDraftRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const syncWithServerDraft = async () => {
+      const serverDraft = await loadExperimentDraftFromServer(user);
+      if (cancelled || hasUserActedOnDraftRef.current) return;
+
+      const freshest = pickFreshestDraft(pendingDraft, serverDraft);
+      if (freshest && freshest !== pendingDraft) {
+        setPendingDraft(freshest);
+        setIsDraftPromptOpen(true);
+      }
+    };
+
+    syncWithServerDraft();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const [ExperimentTitle, setExperimentTitle] = useState('');
   const [ExperimentTitleICF, setExperimentTitleICF] = useState('');
   const [ExperimentDescICF, setExperimentDescICF] = useState('');
@@ -77,10 +102,15 @@ const CreateExperiment = () => {
     setIsDraftPromptOpen(false);
   };
 
-  const handleResumeDraft = () => applyDraftValues(pendingDraft);
+  const handleResumeDraft = () => {
+    hasUserActedOnDraftRef.current = true;
+    applyDraftValues(pendingDraft);
+  };
 
   const handleDiscardDraft = () => {
+    hasUserActedOnDraftRef.current = true;
     clearExperimentDraft(user?.id);
+    clearExperimentDraftFromServer(user);
     setIsDraftPromptOpen(false);
   };
 
@@ -98,7 +128,7 @@ const CreateExperiment = () => {
     ExperimentSurveys,
   };
 
-  useExperimentDraftAutosave(user?.id, currentDraftValues, { enabled: !isDraftPromptOpen });
+  useExperimentDraftAutosave(user, currentDraftValues, { enabled: !isDraftPromptOpen });
 
   const [feedback, setFeedback] = useState({
     open: false,
@@ -139,7 +169,7 @@ const CreateExperiment = () => {
 
       const link = document.createElement('a');
       link.href = url;
-      link.download = `rascunho_${slug}.yaml`;
+      link.download = `draft_${slug}.yaml`;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
@@ -248,6 +278,7 @@ const CreateExperiment = () => {
       );
 
       clearExperimentDraft(user?.id);
+      clearExperimentDraftFromServer(user);
       setFeedback({
         open: true,
         message: t('Success') || 'Experimento criado!',
@@ -270,10 +301,49 @@ const CreateExperiment = () => {
 
   const makeStepIcon =
     (completedSteps) =>
-    ({ active, icon }) => {
-      const isCompleted = completedSteps.has(icon - 1);
+      ({ active, icon }) => {
+        const isCompleted = completedSteps.has(icon - 1);
 
-      if (isCompleted) {
+        if (isCompleted) {
+          return (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 30,
+                height: 30,
+                borderRadius: '50%',
+                backgroundColor: '#1976d2',
+                color: '#fff',
+                fontSize: 16,
+              }}
+            >
+              ✓
+            </div>
+          );
+        }
+        if (active) {
+          return (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 30,
+                height: 30,
+                borderRadius: '50%',
+                backgroundColor: '#f2912d',
+                color: '#fff',
+                fontSize: 14,
+                fontWeight: 'bold',
+                boxShadow: '0 0 0 4px rgba(242, 145, 45, 0.25)',
+              }}
+            >
+              {icon}
+            </div>
+          );
+        }
         return (
           <div
             style={{
@@ -283,54 +353,15 @@ const CreateExperiment = () => {
               width: 30,
               height: 30,
               borderRadius: '50%',
-              backgroundColor: '#1976d2',
-              color: '#fff',
-              fontSize: 16,
-            }}
-          >
-            ✓
-          </div>
-        );
-      }
-      if (active) {
-        return (
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: 30,
-              height: 30,
-              borderRadius: '50%',
-              backgroundColor: '#f2912d',
-              color: '#fff',
+              backgroundColor: '#e0e0e0',
+              color: '#9e9e9e',
               fontSize: 14,
-              fontWeight: 'bold',
-              boxShadow: '0 0 0 4px rgba(242, 145, 45, 0.25)',
             }}
           >
             {icon}
           </div>
         );
-      }
-      return (
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            width: 30,
-            height: 30,
-            borderRadius: '50%',
-            backgroundColor: '#e0e0e0',
-            color: '#9e9e9e',
-            fontSize: 14,
-          }}
-        >
-          {icon}
-        </div>
-      );
-    };
+      };
   const CustomStepIcon = makeStepIcon(completedSteps);
 
   return (

--- a/src/pages/Experiment/CreateExperiment.js
+++ b/src/pages/Experiment/CreateExperiment.js
@@ -3,9 +3,11 @@
  * Licensed under The MIT License [see LICENSE for details]
  */
 
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
+import * as yaml from 'js-yaml';
 import { api } from '../../config/axios';
 import {
+  Box,
   Typography,
   Stepper,
   Step,
@@ -57,43 +59,46 @@ const CreateExperiment = () => {
   const [completedSteps, setCompletedSteps] = useState(new Set());
   const [isCurrentStepValid, setIsCurrentStepValid] = useState(true);
 
-  const handleResumeDraft = () => {
-    setExperimentTitle(pendingDraft.ExperimentTitle || '');
-    setExperimentTitleICF(pendingDraft.ExperimentTitleICF || '');
-    setExperimentDescICF(pendingDraft.ExperimentDescICF || '');
-    setExperimentType(pendingDraft.ExperimentType || 'within-subject');
-    setBtypeExperiment(pendingDraft.BtypeExperiment || 'random');
-    setExperimentDesc(pendingDraft.ExperimentDesc || '');
-    setExperimentTasks(pendingDraft.ExperimentTasks || []);
-    setExperimentSurveys(pendingDraft.ExperimentSurveys || []);
-    setStep(pendingDraft.step || 0);
-    setMaxStep(pendingDraft.maxStep || 0);
-    setCompletedSteps(new Set(pendingDraft.completedSteps || []));
+  const [saveFailure, setSaveFailure] = useState({ open: false, message: '' });
+  const draftFileInputRef = useRef(null);
+
+  const applyDraftValues = (values) => {
+    setExperimentTitle(values.ExperimentTitle || '');
+    setExperimentTitleICF(values.ExperimentTitleICF || '');
+    setExperimentDescICF(values.ExperimentDescICF || '');
+    setExperimentType(values.ExperimentType || 'within-subject');
+    setBtypeExperiment(values.BtypeExperiment || 'random');
+    setExperimentDesc(values.ExperimentDesc || '');
+    setExperimentTasks(values.ExperimentTasks || []);
+    setExperimentSurveys(values.ExperimentSurveys || []);
+    setStep(values.step || 0);
+    setMaxStep(values.maxStep || 0);
+    setCompletedSteps(new Set(values.completedSteps || []));
     setIsDraftPromptOpen(false);
   };
+
+  const handleResumeDraft = () => applyDraftValues(pendingDraft);
 
   const handleDiscardDraft = () => {
     clearExperimentDraft(user?.id);
     setIsDraftPromptOpen(false);
   };
 
-  useExperimentDraftAutosave(
-    user?.id,
-    {
-      step,
-      maxStep,
-      completedSteps: [...completedSteps],
-      ExperimentTitle,
-      ExperimentTitleICF,
-      ExperimentDescICF,
-      ExperimentType,
-      BtypeExperiment,
-      ExperimentDesc,
-      ExperimentTasks,
-      ExperimentSurveys,
-    },
-    { enabled: !isDraftPromptOpen },
-  );
+  const currentDraftValues = {
+    step,
+    maxStep,
+    completedSteps: [...completedSteps],
+    ExperimentTitle,
+    ExperimentTitleICF,
+    ExperimentDescICF,
+    ExperimentType,
+    BtypeExperiment,
+    ExperimentDesc,
+    ExperimentTasks,
+    ExperimentSurveys,
+  };
+
+  useExperimentDraftAutosave(user?.id, currentDraftValues, { enabled: !isDraftPromptOpen });
 
   const [feedback, setFeedback] = useState({
     open: false,
@@ -104,6 +109,89 @@ const CreateExperiment = () => {
   const handleCloseFeedback = (event, reason) => {
     if (reason === 'clickaway') return;
     setFeedback({ ...feedback, open: false });
+  };
+
+  const getExperimentErrorMessage = (error) => {
+    if (!error?.response) {
+      return t('experiment_create_network_error');
+    }
+    const data = error.response.data;
+    if (Array.isArray(data?.message)) {
+      return data.message.map((msg) => t(msg, { defaultValue: msg })).join(' ');
+    }
+    if (typeof data?.message === 'string') {
+      return t(data.message, { defaultValue: data.message });
+    }
+    return t('experiment_create_unknown_error');
+  };
+
+  // Backup export/import happens entirely client-side: this is the escape
+  // hatch offered when the backend is unreachable, so it must not itself
+  // depend on the backend.
+  const handleDownloadDraftBackup = () => {
+    try {
+      const yamlContent = yaml.dump(currentDraftValues);
+      const blob = new Blob([yamlContent], { type: 'application/x-yaml' });
+      const url = window.URL.createObjectURL(blob);
+      const slug =
+        (ExperimentTitle || 'experimento').trim().replace(/[^a-zA-Z0-9]+/g, '_').slice(0, 60) ||
+        'experimento';
+
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `rascunho_${slug}.yaml`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error('Erro ao exportar rascunho:', error);
+      setFeedback({
+        open: true,
+        message: t('draft_export_error'),
+        severity: 'error',
+        isLoading: false,
+      });
+    }
+  };
+
+  const handleDraftFileSelected = async (event) => {
+    const file = event.target.files[0];
+    event.target.value = '';
+    if (!file) return;
+
+    if (!file.name.endsWith('.yaml') && !file.name.endsWith('.yml')) {
+      setFeedback({
+        open: true,
+        message: t('import_invalid_file'),
+        severity: 'error',
+        isLoading: false,
+      });
+      return;
+    }
+
+    try {
+      const text = await file.text();
+      const parsed = yaml.load(text);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error('Invalid draft structure');
+      }
+      applyDraftValues(parsed);
+      setFeedback({
+        open: true,
+        message: t('draft_imported_success'),
+        severity: 'success',
+        isLoading: false,
+      });
+    } catch (error) {
+      console.error('Erro ao importar rascunho:', error);
+      setFeedback({
+        open: true,
+        message: t('draft_import_invalid_file'),
+        severity: 'error',
+        isLoading: false,
+      });
+    }
   };
 
   const STEPS = [
@@ -168,15 +256,16 @@ const CreateExperiment = () => {
       });
       return true;
     } catch (error) {
-      console.error(t('Error creating experiment'), error);
-      setFeedback({
-        open: true,
-        message: t('Error') || 'Falha ao criar o experimento.',
-        severity: 'error',
-        isLoading: false,
-      });
+      console.error('Erro ao criar experimento:', error);
+      setFeedback({ open: false, message: '', severity: 'error', isLoading: false });
+      setSaveFailure({ open: true, message: getExperimentErrorMessage(error) });
       return false;
     }
+  };
+
+  const handleRetryCreateExperiment = () => {
+    setSaveFailure({ open: false, message: '' });
+    handleCreateExperiment();
   };
 
   const makeStepIcon =
@@ -259,9 +348,40 @@ const CreateExperiment = () => {
         </DialogActions>
       </Dialog>
 
+      <Dialog
+        open={saveFailure.open}
+        onClose={() => setSaveFailure({ open: false, message: '' })}
+      >
+        <DialogTitle>{t('experiment_save_failed_title')}</DialogTitle>
+        <DialogContent>
+          <DialogContentText sx={{ mb: 1 }}>{saveFailure.message}</DialogContentText>
+          <DialogContentText>{t('experiment_save_failed_message')}</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setSaveFailure({ open: false, message: '' })}>{t('close')}</Button>
+          <Button onClick={handleDownloadDraftBackup}>{t('download_draft_backup')}</Button>
+          <Button onClick={handleRetryCreateExperiment} variant="contained" autoFocus>
+            {t('retry')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
       <Typography variant="h4" component="h1" gutterBottom align="center">
         {t('Experiment_create')}
       </Typography>
+
+      <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
+        <input
+          ref={draftFileInputRef}
+          type="file"
+          accept=".yaml,.yml"
+          style={{ display: 'none' }}
+          onChange={handleDraftFileSelected}
+        />
+        <Button size="small" onClick={() => draftFileInputRef.current?.click()}>
+          {t('import_draft')}
+        </Button>
+      </Box>
 
       <Stepper sx={{ display: { xs: 'none', sm: 'flex' } }} activeStep={step} alternativeLabel>
         {STEPS.map((s) => (

--- a/src/pages/components/Researcher.js
+++ b/src/pages/components/Researcher.js
@@ -19,8 +19,14 @@ import {
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { ExperimentAccordion } from '../../components/Researcher/ExperimentAccordion';
+import { DraftExperimentCard } from '../../components/Researcher/DraftExperimentCard';
 import styles from '../../style/researcher.module.css';
 import { LoadingState } from '../../components/Researcher/LoadingState';
+import {
+  clearExperimentDraft,
+  clearExperimentDraftFromServer,
+  isExperimentDraftMeaningful,
+} from '../../hooks/useExperimentDraftAutosave';
 
 const experimentStatus = Object.freeze({
   NOT_STARTED: 'NOT_STARTED',
@@ -41,6 +47,8 @@ const Researcher = () => {
   const [experimentToDelete, setExperimentToDelete] = useState(null);
   const [editWarningModalOpen, setEditWarningModalOpen] = useState(false);
   const [experimentToEdit, setExperimentToEdit] = useState(null);
+  const [draft, setDraft] = useState(null);
+  const [discardDraftModalOpen, setDiscardDraftModalOpen] = useState(false);
   const user = JSON.parse(localStorage.getItem('user'));
   const { t } = useTranslation();
   const fileInputRef = useRef(null);
@@ -91,9 +99,26 @@ const Researcher = () => {
     [checkExperimentParticipants],
   );
 
+  const fetchDraft = useCallback(async () => {
+    try {
+      const { data: serverDraft } = await api.get(`experiment-draft/${user.id}`, {
+        headers: { Authorization: `Bearer ${user.accessToken}` },
+      });
+      setDraft(
+        serverDraft?.payload && isExperimentDraftMeaningful(serverDraft.payload)
+          ? { ...serverDraft.payload, savedAt: serverDraft.lastChangeAt }
+          : null,
+      );
+    } catch (error) {
+      console.error('Error fetching experiment draft:', error);
+    }
+  }, [user.accessToken, user.id]);
+
   const fetchAllExperiments = useCallback(async () => {
     setIsLoading(true);
     setError(null);
+
+    fetchDraft();
 
     try {
       const { data: ownedExperiments } = await api.get(`experiment/owner/${user.id}`, {
@@ -121,7 +146,7 @@ const Researcher = () => {
     } finally {
       setIsLoading(false);
     }
-  }, [user.accessToken, user.id, t, checkAllExperimentsParticipants]);
+  }, [user.accessToken, user.id, t, checkAllExperimentsParticipants, fetchDraft]);
 
   useEffect(() => {
     fetchAllExperiments();
@@ -394,6 +419,19 @@ const Researcher = () => {
     navigate(`/experiments/${experimentId}/participants`);
   };
 
+  const handleContinueDraft = () => navigate('/experiments/new');
+
+  const handleDiscardDraftClick = () => setDiscardDraftModalOpen(true);
+
+  const cancelDiscardDraft = () => setDiscardDraftModalOpen(false);
+
+  const confirmDiscardDraft = () => {
+    clearExperimentDraft(user.id);
+    clearExperimentDraftFromServer(user);
+    setDraft(null);
+    setDiscardDraftModalOpen(false);
+  };
+
   return (
     <div className={styles.researcherContainer}>
       <Dialog
@@ -425,6 +463,27 @@ const Researcher = () => {
           </Button>
           <Button onClick={confirmDeleteExperiment} color="error" variant="contained" autoFocus>
             {t('delete_confirm') || 'EXCLUIR'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Dialog
+        open={discardDraftModalOpen}
+        onClose={cancelDiscardDraft}
+        aria-labelledby="discard-draft-dialog-title"
+        aria-describedby="discard-draft-dialog-description"
+      >
+        <DialogTitle id="discard-draft-dialog-title">{t('discard_draft_title')}</DialogTitle>
+        <DialogContent>
+          <DialogContentText id="discard-draft-dialog-description">
+            {t('discard_draft_message')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions sx={{ padding: '16px 24px' }}>
+          <Button onClick={cancelDiscardDraft} color="primary" variant="outlined">
+            {t('cancel') || 'CANCELAR'}
+          </Button>
+          <Button onClick={confirmDiscardDraft} color="error" variant="contained" autoFocus>
+            {t('draft_card_discard')}
           </Button>
         </DialogActions>
       </Dialog>
@@ -504,6 +563,14 @@ const Researcher = () => {
 
         {activeTab === 0 && (
           <>
+            {draft && (
+              <DraftExperimentCard
+                draft={draft}
+                onContinue={handleContinueDraft}
+                onDiscard={handleDiscardDraftClick}
+                t={t}
+              />
+            )}
             {experimentsOwner?.length > 0 ? (
               experimentsOwner.map((experiment, index) => (
                 <ExperimentAccordion


### PR DESCRIPTION
- The experiment draft is autosaved (debounced) to localStorage and mirrored to the backend (`PUT/GET/DELETE /experiment-draft/:userId`) at every step of the wizard, so it survives network failures, page refreshes, or browser crashes.
- When reopening the creation screen, the system picks the freshest draft between local and server and prompts the user to resume or discard it.
- The pending draft also shows up as a card on the researcher home screen (continue/discard).
- Autosave visual feedback: a thin progress bar flashes briefly at the top of the screen while saving; if the backend becomes unreachable, a persistent warning tells the researcher to pause until the connection is back.
- Manual YAML backup (download) remains as an escape hatch for when the final submission fails; YAML import was removed (per review feedback) to avoid keeping two confusing, parallel recovery paths.